### PR TITLE
Update Orama to v2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@opendocsg/pdf2md": "^0.1.28",
-        "@orama/orama": "^2.0.0-beta.10",
+        "@orama/orama": "^2.0.7",
         "@xenova/transformers": "^2.6.2",
         "electron-squirrel-startup": "^1.0.0",
         "langchain": "^0.0.170",
@@ -686,9 +686,9 @@
       }
     },
     "node_modules/@orama/orama": {
-      "version": "2.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-2.0.0-beta.10.tgz",
-      "integrity": "sha512-gZGuEiOVx1iYJS+qPxHivikViY/3B9YN4nYCPUEdE2XoqsptrjjY4HT82lc4OfXA6gHKp4x/A4fuRTiGHlUktQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-2.0.7.tgz",
+      "integrity": "sha512-ezB13u8JyHuSQsIfyR8Cm3LfSifjqqJ0meQHNVWJNnmpp+fKiJeOC/U85WfX2h+lsgfZO+VW0t4cFWCbeAdBsA==",
       "engines": {
         "node": ">= 16.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "@opendocsg/pdf2md": "^0.1.28",
-    "@orama/orama": "^2.0.0-beta.10",
+    "@orama/orama": "^2.0.7",
     "@xenova/transformers": "^2.6.2",
     "electron-squirrel-startup": "^1.0.0",
     "langchain": "^0.0.170",

--- a/src/service/vector.js
+++ b/src/service/vector.js
@@ -1,4 +1,4 @@
-const { create, count, insertMultiple, searchVector } = require("@orama/orama")
+const { create, count, insertMultiple, search: oramaSearch } = require("@orama/orama")
 
 class VectorStore {
   static instance = null;
@@ -32,9 +32,12 @@ class VectorStore {
   }
 
   async search(embedding, limit) {
-    const searchResult = await searchVector(this.db, {
-      vector: embedding,
-      property: 'embedding',
+    const searchResult = await oramaSearch(this.db, {
+      mode: 'vector',
+      vector: {
+        value: embedding,
+        property: 'embedding',
+      },
       similarity: 0.1, // get as many results as possible
       limit: limit,
     });


### PR DESCRIPTION
I noticed you're still using a beta version of Orama 2.0. I updated it to its latest, stable version addressing all the breaking changes that come with it.

Happy to provide support with Orama if you need it! 